### PR TITLE
Add Github url in DESCRIPTION to fix missing website icon

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,5 +35,5 @@ LazyData: true
 RoxygenNote: 6.1.1
 Roxygen: list(markdown = TRUE)
 ByteCompile: true
-URL: https://tidymodels.github.io/embed
+URL: https://tidymodels.github.io/embed, https://github.com/tidymodels/embed
 BugReports: https://github.com/tidymodels/embed/issues


### PR DESCRIPTION
This PR adds the GitHub `embed` link so pkgdown generates the Github icon on the website. This makes it a little easier to get back to the GitHub page from the website.

Here's the before and after running `pkgdown::build_home()` locally.

Before:
<img width="587" alt="before" src="https://user-images.githubusercontent.com/20732748/70851753-ebcc1100-1e5e-11ea-8874-39b13cd49c97.png">

After:
<img width="542" alt="after" src="https://user-images.githubusercontent.com/20732748/70851755-f090c500-1e5e-11ea-829d-1fed1c2faf40.png">

I didn't `pkgdown::build_site`, because I wasn't sure if there was some CI that did it automatically. 
