### PR TITLE
Use rlang's warn, abort

### DIFF
--- a/R/bayes.R
+++ b/R/bayes.R
@@ -108,7 +108,7 @@ step_lencode_bayes <-
            skip = FALSE,
            id = rand_id("lencode_bayes")) {
     if (is.null(outcome))
-      stop("Please list a variable in `outcome`", call. = FALSE)
+      rlang::abort("Please list a variable in `outcome`")
     add_step(
       recipe,
       step_lencode_bayes_new(

--- a/R/glm.R
+++ b/R/glm.R
@@ -79,7 +79,7 @@ step_lencode_glm <-
            skip = FALSE,
            id = rand_id("lencode_bayes")) {
     if (is.null(outcome))
-      stop("Please list a variable in `outcome`", call. = FALSE)
+      rlang::abort("Please list a variable in `outcome`")
     add_step(
       recipe,
       step_lencode_glm_new(

--- a/R/lme.R
+++ b/R/lme.R
@@ -138,6 +138,7 @@ prep.step_lencode_mixed <- function(x, training, info = NULL, ...) {
         "Mixed effects methods here are only implemented for ",
         "two-class problems."
       )
+      )
     }
   }
   res <-

--- a/R/lme.R
+++ b/R/lme.R
@@ -95,7 +95,7 @@ step_lencode_mixed <-
            skip = FALSE,
            id = rand_id("lencode_bayes")) {
     if (is.null(outcome))
-      stop("Please list a variable in `outcome`", call. = FALSE)
+      rlang::abort("Please list a variable in `outcome`")
     add_step(
       recipe,
       step_lencode_mixed_new(
@@ -134,9 +134,10 @@ prep.step_lencode_mixed <- function(x, training, info = NULL, ...) {
   y_name <- terms_select(x$outcome, info = info)
   if (is.factor(training[[y_name]])) {
     if (length(levels(training[[y_name]])) > 2) {
-      stop("Mixed effects methods here are on;y implemented for ",
-           "two-class problems.",
-           call. = FALSE)
+      rlang::abort(paste0(
+        "Mixed effects methods here are only implemented for ",
+        "two-class problems."
+      )
     }
   }
   res <-

--- a/R/tf.R
+++ b/R/tf.R
@@ -148,7 +148,7 @@ step_embed <-
            skip = FALSE,
            id = rand_id("lencode_bayes")) {
     if (is.null(outcome))
-      stop("Please list a variable in `outcome`", call. = FALSE)
+      rlang::abort("Please list a variable in `outcome`")
     add_step(
       recipe,
       step_embed_new(
@@ -448,11 +448,11 @@ embed_control <- function(
   callbacks = NULL
 ) {
   if(batch_size < 1)
-    stop("`batch_size` should be a positive integer", call. = FALSE)
+    rlang::abort("`batch_size` should be a positive integer")
   if(epochs < 1)
-    stop("`epochs` should be a positive integer", call. = FALSE)  
+    rlang::abort("`epochs` should be a positive integer")  
   if(validation_split < 0 | validation_split > 1)
-    stop("`validation_split` should be on [0, 1)", call. = FALSE)
+    rlang::abort("`validation_split` should be on [0, 1)")
   list(
     loss = loss, metrics = metrics, optimizer = optimizer, epochs = epochs, 
     validation_split = validation_split, batch_size = batch_size,
@@ -469,8 +469,12 @@ tf_options_check <- function(opt) {
                  'verbose')
   
   if (length(setdiff(exp_names, names(opt))) > 0)
-    stop("The following options are missing from the `options`: ",
-         paste0(setdiff(exp_names, names(opt)), collapse = ",")) 
+    rlang::abort(
+      paste0(
+        "The following options are missing from the `options`: ",
+        paste0(setdiff(exp_names, names(opt)), collapse = ",")
+      )
+    )
   opt
 }
 
@@ -478,7 +482,7 @@ tf_options_check <- function(opt) {
 #' @importFrom stats model.matrix
 class2ind <- function (x)  {
   if (!is.factor(x)) 
-    stop("'x' should be a factor")
+    rlang::abort("'x' should be a factor")
   y <- model.matrix(~x - 1)
   colnames(y) <- gsub("^x", "", colnames(y))
   attributes(y)$assign <- NULL

--- a/R/umap.R
+++ b/R/umap.R
@@ -111,7 +111,7 @@ step_umap <-
       seed <- as.integer(seed)
     }
     if (length(seed) != 2) {
-      stop("Two integers are required for `seed`.", call. = FALSE)
+      rlang::abort("Two integers are required for `seed`.")
     }
 
     add_step(

--- a/R/woe.R
+++ b/R/woe.R
@@ -115,7 +115,7 @@ step_woe <- function(recipe,
                      skip = FALSE,
                      id = rand_id("woe")) {
   if (missing(outcome)) {
-    stop('argument "outcome" is missing, with no default', call. = FALSE)
+    rlang::abort('argument "outcome" is missing, with no default')
   }
   
   add_step(
@@ -174,9 +174,8 @@ woe_table <- function(predictor, outcome, Laplace = 1e-6) {
   outcome_original_labels <- unique(outcome)
   
   if (length(outcome_original_labels) != 2) {
-    stop(sprintf("'outcome' must have exactly 2 categories (has %s)",
-                 length(outcome_original_labels)),
-         call. = FALSE)
+    rlang::abort(sprintf("'outcome' must have exactly 2 categories (has %s)",
+                 length(outcome_original_labels)))
   }
   
   if (is.factor(predictor)) {
@@ -286,10 +285,10 @@ dictionary <- function(.data, outcome, ..., Laplace = 1e-6) {
 #' @export
 add_woe <- function(.data, outcome, ..., dictionary = NULL, prefix = "woe") {
   if (missing(.data)) {
-    stop('argument ".data" is missing, with no default', call. = FALSE)
+    rlang::abort('argument ".data" is missing, with no default')
   }
   if (missing(outcome)) {
-    stop('argument "outcome" is missing, with no default', call. = FALSE)
+    rlang::abort('argument "outcome" is missing, with no default')
   }
   
   outcome <- rlang::enquo(outcome)
@@ -297,13 +296,13 @@ add_woe <- function(.data, outcome, ..., dictionary = NULL, prefix = "woe") {
     dictionary <- dictionary(.data,!!outcome, ...)
   } else {
     if (is.null(dictionary$variable)) {
-      stop('column "variable" is missing in dictionary.', call. = FALSE)
+      rlang::abort('column "variable" is missing in dictionary.')
     }
     if (is.null(dictionary$predictor)) {
-      stop('column "predictor" is missing in dictionary.', call. = FALSE)
+      rlang::abort('column "predictor" is missing in dictionary.')
     }
     if (is.null(dictionary$woe)) {
-      stop('column "woe" is missing in dictionary.', call. = FALSE)
+      rlang::abort('column "woe" is missing in dictionary.')
     }
   }
   
@@ -313,9 +312,13 @@ add_woe <- function(.data, outcome, ..., dictionary = NULL, prefix = "woe") {
     level_counts,
     names(level_counts),
     ~ if(.x > 50)
-      warning("Variable ", .y, " has ", .x,
-              " unique values. Is this expected? In case of numeric variable, see ?step_discretize()."),
-    call. = FALSE)
+      rlang::warn(
+        paste0(
+          "Variable ", .y, " has ", .x,
+          " unique values. Is this expected? In case of numeric variable, ",
+          "see ?step_discretize().")
+        )
+  )
   
   
   if (missing(...)) {


### PR DESCRIPTION
Replace `warning()` with `rlang::warn()` and `stop()` with `rlang::abort()`.

Fixes #34 