### PR TITLE
Fix the outcome parameter's description of `step_embed()`

### DIFF
--- a/R/tf.R
+++ b/R/tf.R
@@ -15,8 +15,7 @@
 #'  role should they be assigned?. By default, the function assumes
 #'  that the embedding variables created will be used as predictors in a model.
 #' @param outcome A call to `vars` to specify which variable is
-#'  used as the outcome in the neural network. Only
-#'  numeric and two-level factors are currently supported.
+#'  used as the outcome in the neural network.
 #' @param predictors An optional call to `vars` to specify any
 #'  variables to be added as additional predictors in the neural
 #'  network. These variables should be numeric and perhaps centered

--- a/man/step_embed.Rd
+++ b/man/step_embed.Rd
@@ -52,8 +52,7 @@ that the embedding variables created will be used as predictors in a model.}
 preprocessing have been estimated.}
 
 \item{outcome}{A call to \code{vars} to specify which variable is
-used as the outcome in the neural network. Only
-numeric and two-level factors are currently supported.}
+used as the outcome in the neural network.}
 
 \item{predictors}{An optional call to \code{vars} to specify any
 variables to be added as additional predictors in the neural


### PR DESCRIPTION
It seems to me that it is no longer the case that `outcome` can only be numeric or two-level factors. Please correct me if I'm wrong. :)