### PR TITLE
Harmonize `keep_original_cols` in embed

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@ Applications/Tensorflow.Rmd
 ^\.github$
 ^CODE_OF_CONDUCT\.md$
 ^LICENSE\.md$
+^man-roxygen$

--- a/R/discretize_cart.R
+++ b/R/discretize_cart.R
@@ -30,12 +30,7 @@
 #'  conducted on new data (e.g. processing the outcome variable(s)).
 #'  Care should be taken when using `skip = TRUE` as it may affect
 #'  the computations for subsequent operations
-#' @return An updated version of `recipe` with the new step added to the
-#'  sequence of existing steps (if any).
-#' @keywords binning
-#' @concept preprocessing
-#' @concept discretization
-#' @concept factors
+#' @template step-return
 #' @export
 #' @details `step_discretize_cart()` creates non-uniform bins from numerical
 #'  variables by utilizing the information about the outcome variable and

--- a/R/discretize_xgb.R
+++ b/R/discretize_xgb.R
@@ -35,13 +35,7 @@
 #'  conducted on new data (e.g. processing the outcome variable(s)).
 #'  Care should be taken when using `skip = TRUE` as it may affect
 #'  the computations for subsequent operations
-#' @return An updated version of `recipe` with the new step added to the
-#'  sequence of existing steps (if any).
-#' @keywords binning
-#' @concept preprocessing
-#' @concept xgboost
-#' @concept discretization
-#' @concept factors
+#' @template step-return
 #' @export
 #' @details `step_discretize_xgb()` creates non-uniform bins from numerical
 #'  variables by utilizing the information about the outcome variable and

--- a/R/umap.R
+++ b/R/umap.R
@@ -3,17 +3,7 @@
 #' `step_umap` creates a *specification* of a recipe step that
 #'  will project a set of features into a smaller space. 
 #'
-#' @param recipe A recipe object. The step will be added to the
-#'  sequence of operations for this recipe.
-#' @param ... One or more selector functions to choose variables. For
-#'  `step_umap`, this indicates the variables to be encoded into a numeric
-#'  format. Numeric and factor variables can be used. See
-#'  [recipes::selections()] for more details. For the `tidy` method, these are
-#'  not currently used.
-#' @param role For model terms created by this step, what analysis role should
-#'  they be assigned?. By default, the function assumes that the new embedding
-#'  columns created by the original variables will be used as predictors in a
-#'  model.
+#' @inheritParams recipes::step_pca
 #' @param min_dist The effective minimum distance between embedded points.
 #' @param num_comp An integer for the number of UMAP components. If `num_comp`
 #' is greater than the number of selected columns minus one, the smaller value
@@ -35,28 +25,12 @@
 #'  numerical methods. The default pulls from the main session's stream of
 #'  numbers and will give reproducible results if the seed is set prior to
 #'  calling [prep.recipe()] or [bake.recipe()].
-#' @param keep_original_cols A logical to keep the original variables in the
-#'  output. Defaults to `FALSE`.
 #' @param retain Use `keep_original_cols` instead to specify whether the
 #'  original predictors should be retained along with the new embedding 
 #'  variables.
 #' @param object An object that defines the encoding. This is
 #'  `NULL` until the step is trained by [recipes::prep.recipe()].
-#' @param skip A logical. Should the step be skipped when the recipe is baked
-#'  by [recipes::bake.recipe()]? While all operations are baked when
-#'  [recipes::prep.recipe()] is run, some operations may not be able to be
-#'  conducted on new data (e.g. processing the outcome variable(s)). Care should
-#'  be taken when using `skip = TRUE` as it may affect the computations for
-#'  subsequent operations
-#' @param trained A logical to indicate if the quantities for preprocessing
-#'  have been estimated.
-#' @param id A character string that is unique to this step to identify it.
-#' @return An updated version of `recipe` with the new step added to the
-#'  sequence of existing steps (if any). For the `tidy` method, a tibble with a
-#'  column called `terms` (the selectors or variables for embedding) is
-#'  returned.
-#' @keywords datagen 
-#' @concept preprocessing encoding
+#' @template step-return
 #' @export
 #' @details 
 #' UMAP, short for Uniform Manifold Approximation and Projection, is a nonlinear 
@@ -248,7 +222,7 @@ bake.step_umap <- function(object, new_data, ...) {
   res <- dplyr::as_tibble(res)
   new_data <- bind_cols(new_data, res)
 
-  keep_original_cols <- get_keep_original_cols(object)
+  keep_original_cols <- recipes::get_keep_original_cols(object)
   if (!keep_original_cols) {
     new_data <- new_data[, !(colnames(new_data) %in% object$object$xnames), drop = FALSE]
   }

--- a/man-roxygen/step-return.R
+++ b/man-roxygen/step-return.R
@@ -1,0 +1,2 @@
+#' @return An updated version of `recipe` with the new step added to the
+#'  sequence of any existing operations.

--- a/man/step_discretize_cart.Rd
+++ b/man/step_discretize_cart.Rd
@@ -63,7 +63,7 @@ the computations for subsequent operations}
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any).
+sequence of any existing operations.
 }
 \description{
 \code{step_discretize_cart} creates a \emph{specification} of a recipe step that will
@@ -109,7 +109,3 @@ bake(cart_rec, ad_data_te, tau)
 \code{\link[=step_discretize_xgb]{step_discretize_xgb()}}, \code{\link[recipes:recipe]{recipes::recipe()}},
 \code{\link[recipes:prep]{recipes::prep.recipe()}}, \code{\link[recipes:bake]{recipes::bake.recipe()}}
 }
-\concept{discretization}
-\concept{factors}
-\concept{preprocessing}
-\keyword{binning}

--- a/man/step_discretize_xgb.Rd
+++ b/man/step_discretize_xgb.Rd
@@ -72,7 +72,7 @@ the computations for subsequent operations}
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any).
+sequence of any existing operations.
 }
 \description{
 \code{step_discretize_xgb} creates a \emph{specification} of a recipe step that will
@@ -130,8 +130,3 @@ if (rlang::is_installed("xgboost")) {
 \code{\link[=step_discretize_cart]{step_discretize_cart()}}, \code{\link[recipes:recipe]{recipes::recipe()}},
 \code{\link[recipes:prep]{recipes::prep.recipe()}}, \code{\link[recipes:bake]{recipes::bake.recipe()}}
 }
-\concept{discretization}
-\concept{factors}
-\concept{preprocessing}
-\concept{xgboost}
-\keyword{binning}

--- a/man/step_feature_hash.Rd
+++ b/man/step_feature_hash.Rd
@@ -11,8 +11,9 @@ step_feature_hash(
   role = "predictor",
   trained = FALSE,
   num_hash = 2^6,
-  preserve = FALSE,
+  preserve = deprecated(),
   columns = NULL,
+  keep_original_cols = FALSE,
   skip = FALSE,
   id = rand_id("feature_hash")
 )
@@ -20,36 +21,36 @@ step_feature_hash(
 \method{tidy}{step_feature_hash}(x, ...)
 }
 \arguments{
-\item{recipe}{A recipe object. The step will be added to the sequence of
-operations for this recipe.}
+\item{recipe}{A recipe object. The step will be added to the
+sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which \emph{factor}
-variables will be used to create the dummy variables. See \code{\link[=selections]{selections()}} for
-more details. The selected variables must be factors. For the \code{tidy} method,
-these are not currently used.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[recipes:selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the function assumes that the binary dummy
-variable columns created by the original variables will be used as
-predictors in a model.}
+they be assigned? By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
-\item{trained}{A logical to indicate if the quantities for preprocessing
-have been estimated.}
+\item{trained}{A logical to indicate if the quantities for
+preprocessing have been estimated.}
 
 \item{num_hash}{The number of resulting dummy variable columns.}
 
-\item{preserve}{A single logical; should the selected column(s) be retained
-(in addition to the new dummy variables)?}
+\item{preserve}{Use \code{keep_original_cols} instead to specify whether the
+selected column(s) should be retained in addition to the new dummy variables.}
 
 \item{columns}{A character vector for the selected columns. This is \code{NULL}
 until the step is trained by \code{\link[recipes:prep]{recipes::prep.recipe()}}.}
 
-\item{skip}{A logical. Should the step be skipped when the recipe is baked
-by \code{\link[recipes:bake]{recipes::bake.recipe()}}? While all operations are baked when
-\code{\link[recipes:prep]{recipes::prep.recipe()}} is run, some operations may not be able to be
-conducted on new data (e.g. processing the outcome variable(s)). Care should
-be taken when using \code{skip = TRUE} as it may affect the computations for
-subsequent operations.}
+\item{keep_original_cols}{A logical to keep the original variables in the
+output. Defaults to \code{FALSE}.}
+
+\item{skip}{A logical. Should the step be skipped when the
+recipe is baked by \code{\link[recipes:bake]{bake.recipe()}}? While all operations are baked
+when \code{\link[recipes:prep]{prep.recipe()}} is run, some operations may not be able to be
+conducted on new data (e.g. processing the outcome variable(s)).
+Care should be taken when using \code{skip = TRUE} as it may affect
+the computations for subsequent operations.}
 
 \item{id}{A character string that is unique to this step to identify it.}
 
@@ -57,8 +58,7 @@ subsequent operations.}
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any). For the \code{tidy} method, a tibble with
-columns \code{terms} (the selectors or original variables selected).
+sequence of any existing operations.
 }
 \description{
 \code{step_feature_hash} creates a a \emph{specification} of a recipe step that will
@@ -114,8 +114,3 @@ Approach for Predictive Models}. CRC/Chapman Hall
 \seealso{
 \code{\link[recipes:step_dummy]{recipes::step_dummy()}}, \code{\link[recipes:step_zv]{recipes::step_zv()}}
 }
-\concept{dummy_variables}
-\concept{model_specification}
-\concept{preprocessing}
-\concept{variable_encodings}
-\keyword{datagen}

--- a/man/step_umap.Rd
+++ b/man/step_umap.Rd
@@ -31,19 +31,15 @@ step_umap(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose variables. For
-\code{step_umap}, this indicates the variables to be encoded into a numeric
-format. Numeric and factor variables can be used. See
-\code{\link[recipes:selections]{recipes::selections()}} for more details. For the \code{tidy} method, these are
-not currently used.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[recipes:selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the function assumes that the new embedding
-columns created by the original variables will be used as predictors in a
-model.}
+they be assigned? By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
-\item{trained}{A logical to indicate if the quantities for preprocessing
-have been estimated.}
+\item{trained}{A logical to indicate if the quantities for
+preprocessing have been estimated.}
 
 \item{outcome}{A call to \code{vars} to specify which variable is
 used as the outcome in the encoding process (if any).}
@@ -84,12 +80,12 @@ variables.}
 \item{object}{An object that defines the encoding. This is
 \code{NULL} until the step is trained by \code{\link[recipes:prep]{recipes::prep.recipe()}}.}
 
-\item{skip}{A logical. Should the step be skipped when the recipe is baked
-by \code{\link[recipes:bake]{recipes::bake.recipe()}}? While all operations are baked when
-\code{\link[recipes:prep]{recipes::prep.recipe()}} is run, some operations may not be able to be
-conducted on new data (e.g. processing the outcome variable(s)). Care should
-be taken when using \code{skip = TRUE} as it may affect the computations for
-subsequent operations}
+\item{skip}{A logical. Should the step be skipped when the
+recipe is baked by \code{\link[recipes:bake]{bake.recipe()}}? While all operations are baked
+when \code{\link[recipes:prep]{prep.recipe()}} is run, some operations may not be able to be
+conducted on new data (e.g. processing the outcome variable(s)).
+Care should be taken when using \code{skip = TRUE} as it may affect
+the computations for subsequent operations.}
 
 \item{id}{A character string that is unique to this step to identify it.}
 
@@ -97,9 +93,7 @@ subsequent operations}
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any). For the \code{tidy} method, a tibble with a
-column called \code{terms} (the selectors or variables for embedding) is
-returned.
+sequence of any existing operations.
 }
 \description{
 \code{step_umap} creates a \emph{specification} of a recipe step that
@@ -140,5 +134,3 @@ Projection for Dimension Reduction. \url{ https://arxiv.org/abs/1802.03426}.
 
 "How UMAP Works" \url{https://umap-learn.readthedocs.io/en/latest/how_umap_works.html}
 }
-\concept{preprocessing encoding}
-\keyword{datagen}

--- a/tests/testthat/test_hash.R
+++ b/tests/testthat/test_hash.R
@@ -100,3 +100,37 @@ test_that("basic usage - character strings", {
   
 })
 
+test_that('keep_original_cols works', {
+  skip_on_cran()
+  
+  rec <- recipe(x1 ~ x3, data = ex_dat) %>% 
+    step_feature_hash(x3, num_hash = 9, keep_original_cols = TRUE)
+  
+  rec_trained <- prep(rec, training = ex_dat, verbose = FALSE)
+  hash_pred <- bake(rec_trained, new_data = new_dat, all_predictors())
+  
+  expect_equal(
+    colnames(hash_pred),
+    c("x3", paste0("x3_hash_", 1:9))
+  )
+})
+
+test_that('can prep recipes with no keep_original_cols', {
+  skip_on_cran()
+  
+  rec <- recipe(x1 ~ x3, data = ex_dat) %>% 
+    step_feature_hash(x3, num_hash = 9, keep_original_cols = TRUE)
+  
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_warning(
+    rec_trained <- prep(rec, training = ex_dat, verbose = FALSE),
+    "'keep_original_cols' was added to"
+  )
+  
+  expect_error(
+    hash_pred <- bake(rec_trained, new_data = new_dat, all_predictors()),
+    NA
+  )
+  
+})

--- a/tests/testthat/test_umap.R
+++ b/tests/testthat/test_umap.R
@@ -152,4 +152,40 @@ test_that("no outcome", {
   
 })
 
+test_that('keep_original_cols works', {
+  set.seed(11)
+  unsupervised <- 
+    recipe( ~ ., data = tr[, -5]) %>%
+    step_umap(all_predictors(), num_comp = 3, min_dist = .2, learn_rate = .2, 
+              keep_original_cols = TRUE) %>% 
+    prep(training = tr[, -5])
 
+  
+  umap_pred <- bake(unsupervised, new_data = te[, -5], composition = "matrix", all_predictors())
+  
+  expect_equal(
+    colnames(umap_pred),
+    c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width",
+      "umap_1", "umap_2", "umap_3")
+  )
+})
+
+test_that('can prep recipes with no keep_original_cols', {
+  set.seed(11)
+  unsupervised <- 
+    recipe( ~ ., data = tr[, -5]) %>%
+    step_umap(all_predictors(), num_comp = 3, min_dist = .2, learn_rate = .2)
+  
+  unsupervised$steps[[1]]$keep_original_cols <- NULL
+  
+  expect_warning(
+    umap_pred <- prep(unsupervised, training = tr[, -5], verbose = FALSE),
+    "'keep_original_cols' was added to"
+  )
+  
+  expect_error(
+    umap_pred <- bake(umap_pred, new_data = te[, -5], all_predictors()),
+    NA
+  )
+  
+})


### PR DESCRIPTION
Closes #69 

This PR brings embed in line with recipes in terms of `keep_original_cols` (and does some docs clean up while we're here).