### PR TITLE
Add `prefix` argument to `step_umap()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * Updated to use `recipes_eval_select()` from recipes 0.1.17 (#85).
 
-* Added `prefix` argument to `step_umap()` to harmonize with other recipes steps.
+* Added `prefix` argument to `step_umap()` to harmonize with other recipes steps (#93).
 
 # embed 0.1.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Updated to use `recipes_eval_select()` from recipes 0.1.17 (#85).
 
+* Added `prefix` argument to `step_umap()` to harmonize with other recipes steps.
+
 # embed 0.1.4
 
  * Minor release with changes to test for cases when CRAN cannot get `xgboost` to work on their Solaris configuration. 

--- a/R/umap.R
+++ b/R/umap.R
@@ -52,7 +52,6 @@
 #' 
 #' @examples
 #' library(recipes)
-#' library(dplyr)
 #' library(ggplot2)
 #' 
 #' split <- seq.int(1, 150, by = 9)
@@ -70,7 +69,7 @@
 #' theme_set(theme_bw())
 #' 
 #' bake(supervised, new_data = te, Species, starts_with("umap")) %>% 
-#'   ggplot(aes(x = umap_1, y = umap_2, col = Species)) + 
+#'   ggplot(aes(x = UMAP1, y = UMAP2, col = Species)) + 
 #'   geom_point(alpha = .5) 
 
 step_umap <-

--- a/R/umap.R
+++ b/R/umap.R
@@ -37,6 +37,11 @@
 #'  dimension reduction technique that finds local, low-dimensional 
 #'  representations of the data. It can be run unsupervised or supervised with 
 #'  different types of outcome data (e.g. numeric, factor, etc).
+#'  
+#' The new components will have names that begin with `prefix` and a sequence 
+#'  of numbers. The variable names are padded with zeros. For example, if 
+#'  `num_comp < 10`, their names will be `UMAP1` - `UMAP9`. If `num_comp = 101`, 
+#'  the names would be `UMAP001` - `UMAP101`.
 #' 
 #' @references 
 #' McInnes, L., & Healy, J. (2018). UMAP: Uniform Manifold Approximation and 
@@ -81,6 +86,7 @@ step_umap <-
            epochs = NULL,
            options = list(verbose = FALSE, n_threads = 1),
            seed = sample(10^5, 2),
+           prefix = "UMAP",
            keep_original_cols = FALSE,
            retain = deprecated(),
            object = NULL,
@@ -118,6 +124,7 @@ step_umap <-
         epochs = epochs,
         options = options,
         seed = seed,
+        prefix = prefix,
         keep_original_cols = keep_original_cols,
         retain = retain,
         object = object,
@@ -129,7 +136,7 @@ step_umap <-
 
 step_umap_new <-
   function(terms, role, trained, outcome, neighbors, num_comp, min_dist, 
-           learn_rate, epochs, options, seed, keep_original_cols, 
+           learn_rate, epochs, options, seed, prefix, keep_original_cols, 
            retain, object, skip, id) {
     step(
       subclass = "umap",
@@ -144,6 +151,7 @@ step_umap_new <-
       epochs = epochs,
       options = options,
       seed = seed,
+      prefix = prefix,
       keep_original_cols = keep_original_cols,
       retain = retain,
       object = object,
@@ -199,6 +207,7 @@ prep.step_umap <- function(x, training, info = NULL, ...) {
     epochs = x$epochs,
     options = x$options,
     seed = x$seed,
+    prefix = x$prefix,
     keep_original_cols = get_keep_original_cols(x),
     retain = x$retain,
     object = res,
@@ -218,9 +227,10 @@ bake.step_umap <- function(object, new_data, ...) {
       )
   )
   
-  colnames(res) <- names0(ncol(res), "umap_")
-  res <- dplyr::as_tibble(res)
-  new_data <- bind_cols(new_data, res)
+  if (is.null(object$prefix)) object$prefix <- "UMAP"
+  
+  res <- recipes::check_name(res, new_data, object)
+  new_data <- bind_cols(new_data, as_tibble(res))
 
   keep_original_cols <- recipes::get_keep_original_cols(object)
   if (!keep_original_cols) {

--- a/man/step_umap.Rd
+++ b/man/step_umap.Rd
@@ -18,6 +18,7 @@ step_umap(
   epochs = NULL,
   options = list(verbose = FALSE, n_threads = 1),
   seed = sample(10^5, 2),
+  prefix = "UMAP",
   keep_original_cols = FALSE,
   retain = deprecated(),
   object = NULL,
@@ -70,6 +71,9 @@ numerical methods. The default pulls from the main session's stream of
 numbers and will give reproducible results if the seed is set prior to
 calling \code{\link[=prep.recipe]{prep.recipe()}} or \code{\link[=bake.recipe]{bake.recipe()}}.}
 
+\item{prefix}{A character string for the prefix of the resulting new
+variables. See notes below.}
+
 \item{keep_original_cols}{A logical to keep the original variables in the
 output. Defaults to \code{FALSE}.}
 
@@ -104,6 +108,11 @@ UMAP, short for Uniform Manifold Approximation and Projection, is a nonlinear
 dimension reduction technique that finds local, low-dimensional
 representations of the data. It can be run unsupervised or supervised with
 different types of outcome data (e.g. numeric, factor, etc).
+
+The new components will have names that begin with \code{prefix} and a sequence
+of numbers. The variable names are padded with zeros. For example, if
+\code{num_comp < 10}, their names will be \code{UMAP1} - \code{UMAP9}. If \code{num_comp = 101},
+the names would be \code{UMAP001} - \code{UMAP101}.
 }
 \examples{
 library(recipes)

--- a/man/step_umap.Rd
+++ b/man/step_umap.Rd
@@ -116,7 +116,6 @@ the names would be \code{UMAP001} - \code{UMAP101}.
 }
 \examples{
 library(recipes)
-library(dplyr)
 library(ggplot2)
 
 split <- seq.int(1, 150, by = 9)
@@ -134,7 +133,7 @@ supervised <-
 theme_set(theme_bw())
 
 bake(supervised, new_data = te, Species, starts_with("umap")) \%>\% 
-  ggplot(aes(x = umap_1, y = umap_2, col = Species)) + 
+  ggplot(aes(x = UMAP1, y = UMAP2, col = Species)) + 
   geom_point(alpha = .5) 
 }
 \references{

--- a/tests/testthat/test_umap.R
+++ b/tests/testthat/test_umap.R
@@ -166,7 +166,7 @@ test_that('keep_original_cols works', {
   expect_equal(
     colnames(umap_pred),
     c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width",
-      "umap_1", "umap_2", "umap_3")
+      "UMAP1", "UMAP2", "UMAP3")
   )
 })
 


### PR DESCRIPTION
Closes #76 

``` r
library(recipes)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
#> 
#> Attaching package: 'recipes'
#> The following object is masked from 'package:stats':
#> 
#>     step
library(embed)

split <- seq.int(1, 150, by = 9)
tr <- iris[-split, ]
te <- iris[ split, ]

set.seed(11)
supervised <- 
  recipe(Species ~ ., data = tr) %>%
  step_center(all_predictors()) %>% 
  step_scale(all_predictors()) %>% 
  step_umap(all_predictors(), outcome = vars(Species), num_comp = 2) %>% 
  prep(training = tr)

bake(supervised, te)
#> # A tibble: 17 × 3
#>    Species     UMAP1  UMAP2
#>    <fct>       <dbl>  <dbl>
#>  1 setosa      14.1  -1.82 
#>  2 setosa      16.0  -2.83 
#>  3 setosa      15.4  -0.478
#>  4 setosa      14.2  -1.92 
#>  5 setosa      14.8  -1.60 
#>  6 setosa      15.9  -2.92 
#>  7 versicolor -11.2  -5.62 
#>  8 versicolor -10.4  -6.47 
#>  9 versicolor  -4.75  9.48 
#> 10 versicolor  -8.51 -6.03 
#> 11 versicolor  -9.05 -6.15 
#> 12 versicolor  -9.51 -6.56 
#> 13 virginica   -4.58  8.96 
#> 14 virginica   -4.93  6.48 
#> 15 virginica   -4.55  8.96 
#> 16 virginica   -3.92  6.84 
#> 17 virginica   -4.18  7.42
```

<sup>Created on 2021-11-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

This should also handle baking of a recipe that was created before this argument was added