### PR TITLE
Fix rand_id for `step_embed()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # embed (development version)
 
+* `step_embed()` now correctly defaults to have a random id with the word "embed". (#102)
+
 # embed 0.1.5
 
 * Re-licensed package from GPL-2 to MIT. See [consent from copyright holders here](https://github.com/tidymodels/embed/issues/78).

--- a/R/tf.R
+++ b/R/tf.R
@@ -148,7 +148,7 @@ step_embed <-
            mapping = NULL,
            history = NULL,
            skip = FALSE,
-           id = rand_id("lencode_bayes")) {
+           id = rand_id("embed")) {
     # warm start for tf to avoid a bug in tensorflow
     is_tf_available()
     

--- a/man/step_embed.Rd
+++ b/man/step_embed.Rd
@@ -19,7 +19,7 @@ step_embed(
   mapping = NULL,
   history = NULL,
   skip = FALSE,
-  id = rand_id("lencode_bayes")
+  id = rand_id("embed")
 )
 
 \method{tidy}{step_embed}(x, ...)


### PR DESCRIPTION
This PR aims to close #102 

``` r
library(embed)

data(grants, package = "modeldata")
grants_other <- sample_n(grants_other, 500)

recipe(class ~ num_ci + sponsor_code, data = grants_other) %>%
  step_embed(sponsor_code, outcome = vars(class),
             options = embed_control(epochs = 10)) %>% 
  tidy()
#> Loaded Tensorflow version 2.7.0
#> # A tibble: 1 × 6
#>   number operation type  trained skip  id         
#>    <int> <chr>     <chr> <lgl>   <lgl> <chr>      
#> 1      1 step      embed FALSE   FALSE embed_Ika1q
```

<sup>Created on 2022-01-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>