### PR TITLE
Add warning to is_tf_2 if tensorflow is not installed

### DIFF
--- a/R/tf.R
+++ b/R/tf.R
@@ -247,6 +247,14 @@ prep.step_embed <- function(x, training, info = NULL, ...) {
 }
 
 is_tf_2 <- function() {
+  if (!is_tf_available()) {
+    rlang::abort(
+      c(
+        "tensorflow could now be found.", 
+        "PLease run `tensorflow::install_tensorflow()` to install."
+      )
+    )
+  }
   compareVersion("2.0", as.character(tensorflow::tf_version())) <= 0
 }
 


### PR DESCRIPTION
This PR aims to close https://github.com/tidymodels/embed/issues/108

`is_tf_2()`  would throw a bad error if tensorflow isn't installed since `tensorflow::tf_version()` would return `NULL`, which messed us the comparison. 