### PR TITLE
Add subsections to documentation around tidy usage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `step_embed()` now correctly defaults to have a random id with the word "embed". (#102)
 
+* Steps now have a dedicated subsection detailing what happens when `tidy()` is applied. (#105)
+
 # embed 0.1.5
 
 * Re-licensed package from GPL-2 to MIT. See [consent from copyright holders here](https://github.com/tidymodels/embed/issues/78).

--- a/R/bayes.R
+++ b/R/bayes.R
@@ -21,10 +21,10 @@
 #'  [rstanarm::stan_glmer()].
 #' @param mapping A list of tibble results that define the
 #'  encoding. This is `NULL` until the step is trained by
-#'  [recipes::prep.recipe()].
+#'  [recipes::prep()].
 #' @param skip A logical. Should the step be skipped when the
-#'  recipe is baked by [recipes::bake.recipe()]? While all operations are baked
-#'  when [recipes::prep.recipe()] is run, some operations may not be able to be
+#'  recipe is baked by [recipes::bake()]? While all operations are baked
+#'  when [recipes::prep()] is run, some operations may not be able to be
 #'  conducted on new data (e.g. processing the outcome variable(s)).
 #'  Care should be taken when using `skip = TRUE` as it may affect
 #'  the computations for subsequent operations

--- a/R/bayes.R
+++ b/R/bayes.R
@@ -63,7 +63,12 @@
 #'  `cores`, and arguments for the priors (see the links in the
 #'  References below). `prior_intercept` is the argument that has the
 #'  most effect on the amount of shrinkage.
-#'
+#' 
+#' # Tidying
+#' 
+#' When you [`tidy()`][tidy.recipe()] this step, a tibble with columns
+#' `terms` (the selectors or variables selected), `value` and `component` is
+#' returned.
 #'
 #' @references
 #' Micci-Barreca D (2001) "A preprocessing scheme for

--- a/R/discretize_cart.R
+++ b/R/discretize_cart.R
@@ -25,8 +25,8 @@
 #'  each variable. If length zero, splitting could not be used on that column.
 #' @param id A character string that is unique to this step to identify it.
 #' @param skip A logical. Should the step be skipped when the
-#'  recipe is baked by [recipes::bake.recipe()]? While all operations are baked
-#'  when [recipes::prep.recipe()] is run, some operations may not be able to be
+#'  recipe is baked by [recipes::bake()]? While all operations are baked
+#'  when [recipes::prep()] is run, some operations may not be able to be
 #'  conducted on new data (e.g. processing the outcome variable(s)).
 #'  Care should be taken when using `skip = TRUE` as it may affect
 #'  the computations for subsequent operations
@@ -66,7 +66,7 @@
 #'
 #' bake(cart_rec, ad_data_te, tau)
 #' @seealso [embed::step_discretize_xgb()], [recipes::recipe()],
-#' [recipes::prep.recipe()], [recipes::bake.recipe()]
+#' [recipes::prep()], [recipes::bake()]
 #'
 step_discretize_cart <-
   function(recipe,

--- a/R/discretize_cart.R
+++ b/R/discretize_cart.R
@@ -44,6 +44,11 @@
 #'  step will stop with a note about installing the package.
 #'
 #' Note that the original data will be replaced with the new bins.
+#' 
+#' # Tidying
+#'
+#' When you [`tidy()`][tidy.recipe()] this step, a tibble with columns
+#' `terms` (the columns that is selected), `values` is returned.
 #'
 #' @examples
 #' library(modeldata)

--- a/R/discretize_xgb.R
+++ b/R/discretize_xgb.R
@@ -61,6 +61,11 @@
 #'
 #' Note that the original data will be replaced with the new bins.
 #'
+#' # Tidying
+#'
+#' When you [`tidy()`][tidy.recipe()] this step, a tibble with columns
+#' `terms` (the columns that is selected), `values` is returned.
+#'
 #' @examples
 #' library(modeldata)
 #' data(credit_data)

--- a/R/discretize_xgb.R
+++ b/R/discretize_xgb.R
@@ -30,8 +30,8 @@
 #'  each variable.
 #' @param id A character string that is unique to this step to identify it.
 #' @param skip A logical. Should the step be skipped when the
-#'  recipe is baked by [recipes::bake.recipe()]? While all operations are baked
-#'  when [recipes::prep.recipe()] is run, some operations may not be able to be
+#'  recipe is baked by [recipes::bake()]? While all operations are baked
+#'  when [recipes::prep()] is run, some operations may not be able to be
 #'  conducted on new data (e.g. processing the outcome variable(s)).
 #'  Care should be taken when using `skip = TRUE` as it may affect
 #'  the computations for subsequent operations
@@ -83,7 +83,7 @@
 #'   bake(xgb_rec, credit_data_te, Price)
 #' }
 #' @seealso [embed::step_discretize_cart()], [recipes::recipe()],
-#' [recipes::prep.recipe()], [recipes::bake.recipe()]
+#' [recipes::prep()], [recipes::bake()]
 
 step_discretize_xgb <-
   function(recipe,

--- a/R/glm.R
+++ b/R/glm.R
@@ -17,10 +17,10 @@
 #'  numeric and two-level factors are currently supported.
 #' @param mapping A list of tibble results that define the
 #'  encoding. This is `NULL` until the step is trained by
-#'  [recipes::prep.recipe()].
+#'  [recipes::prep()].
 #' @param skip A logical. Should the step be skipped when the
-#'  recipe is baked by [recipes::bake.recipe()]? While all operations are baked
-#'  when [recipes::prep.recipe()] is run, some operations may not be able to be
+#'  recipe is baked by [recipes::bake()]? While all operations are baked
+#'  when [recipes::prep()] is run, some operations may not be able to be
 #'  conducted on new data (e.g. processing the outcome variable(s)).
 #'  Care should be taken when using `skip = TRUE` as it may affect
 #'  the computations for subsequent operations

--- a/R/glm.R
+++ b/R/glm.R
@@ -42,10 +42,15 @@
 #'  coefficients are created using a no intercept model and, when
 #'  two factor outcomes are used, the log-odds reflect the event of
 #'  interest being the _first_ level of the factor.
-
 #'
 #' For novel levels, a slightly timmed average of the coefficients
 #'  is returned.
+#'  
+#' # Tidying
+#' 
+#' When you [`tidy()`][tidy.recipe()] this step, a tibble with columns
+#' `terms` (the selectors or variables selected), `value` and `component` is
+#' returned.
 #'
 #' @references
 #' Micci-Barreca D (2001) "A preprocessing scheme for

--- a/R/hash.R
+++ b/R/hash.R
@@ -27,6 +27,12 @@
 #'  it is likely that some columns will have all zeros. A zero-variance filter
 #'  (via [recipes::step_zv()]) is recommended for any recipe that uses hashed
 #'  columns.
+#'  
+#' # Tidying
+#'
+#' When you [`tidy()`][tidy.recipe()] this step, a tibble with columns
+#' `terms` (the columns that is selected)  is returned.
+#' 
 #' @references
 #' Weinberger, K, A Dasgupta, J Langford, A Smola, and J Attenberg. 2009.
 #'  "Feature Hashing for Large Scale Multitask Learning." In Proceedings of the

--- a/R/hash.R
+++ b/R/hash.R
@@ -9,7 +9,7 @@
 #' @param preserve Use `keep_original_cols` instead to specify whether the
 #' selected column(s) should be retained in addition to the new dummy variables.
 #' @param columns A character vector for the selected columns. This is `NULL`
-#'  until the step is trained by [recipes::prep.recipe()].
+#'  until the step is trained by [recipes::prep()].
 #' @template step-return
 #' @export
 #' @details `step_feature_hash()` will create a set of binary dummy variables

--- a/R/lme.R
+++ b/R/lme.R
@@ -60,7 +60,12 @@
 #'  set by the step) as well as any arguments given to the `options`
 #'  argument to the step. Relevant options include `control` and
 #'  others.
-#'
+#'  
+#' # Tidying
+#' 
+#' When you [`tidy()`][tidy.recipe()] this step, a tibble with columns
+#' `terms` (the selectors or variables selected), `value` and `component` is
+#' returned.
 #'
 #' @references
 #' Micci-Barreca D (2001) "A preprocessing scheme for

--- a/R/lme.R
+++ b/R/lme.R
@@ -19,10 +19,10 @@
 #'  [lme4::glmer()].
 #' @param mapping A list of tibble results that define the
 #'  encoding. This is `NULL` until the step is trained by
-#'  [recipes::prep.recipe()].
+#'  [recipes::prep()].
 #' @param skip A logical. Should the step be skipped when the
-#'  recipe is baked by [recipes::bake.recipe()]? While all operations are baked
-#'  when [recipes::prep.recipe()] is run, some operations may not be able to be
+#'  recipe is baked by [recipes::bake()]? While all operations are baked
+#'  when [recipes::prep()] is run, some operations may not be able to be
 #'  conducted on new data (e.g. processing the outcome variable(s)).
 #'  Care should be taken when using `skip = TRUE` as it may affect
 #'  the computations for subsequent operations

--- a/R/pca_sparse.R
+++ b/R/pca_sparse.R
@@ -22,7 +22,7 @@
 #'  output. Defaults to `FALSE`.
 #' @param options A list of options to the default method for [irlba::ssvd()].
 #' @param res The rotation matrix once this
-#'  preprocessing step has be trained by [prep.recipe()].
+#'  preprocessing step has be trained by [prep()].
 #' @param prefix A character string that will be the prefix to the resulting
 #'  new variables. See notes below.
 #' @return An updated version of `recipe` with the new step added to the

--- a/R/pca_sparse.R
+++ b/R/pca_sparse.R
@@ -47,6 +47,12 @@
 #'  if `num_comp < 10`, their names will be `PC1` - `PC9`.
 #'  If `num_comp = 101`, the names would be `PC001` -
 #'  `PC101`.
+#'  
+#' # Tidying
+#' 
+#' When you [`tidy()`][tidy.recipe()] this step, a tibble with columns
+#' `terms` (the selectors or variables selected), `value` and `component` is
+#' returned.
 #'
 #' @seealso [step_pca_sparse_bayes()]
 #' @examples

--- a/R/pca_sparse_bayes.R
+++ b/R/pca_sparse_bayes.R
@@ -67,6 +67,12 @@
 #'  if `num_comp < 10`, their names will be `PC1` - `PC9`.
 #'  If `num_comp = 101`, the names would be `PC001` -
 #'  `PC101`.
+#' 
+#' # Tidying
+#'
+#' When you [`tidy()`][tidy.recipe()] this step, a tibble with columns
+#' `terms` (the selectors or variables selected), `value` and `component` is
+#' returned.
 #'
 #' @seealso [step_pca_sparse()]
 #' @examples

--- a/R/pca_sparse_bayes.R
+++ b/R/pca_sparse_bayes.R
@@ -28,7 +28,7 @@
 #' @param options A list of options to the default method for
 #' [VBsparsePCA::VBsparsePCA()].
 #' @param res The rotation matrix once this preprocessing step has been trained
-#' by [prep.recipe()].
+#' by [prep()].
 #' @param prefix A character string that will be the prefix to the resulting
 #'  new variables. See notes below.
 #' @return An updated version of `recipe` with the new step added to the

--- a/R/tf.R
+++ b/R/tf.R
@@ -28,13 +28,13 @@
 #' @param options A list of options for the model fitting process.
 #' @param mapping A list of tibble results that define the
 #'  encoding. This is `NULL` until the step is trained by
-#'  [recipes::prep.recipe()].
+#'  [recipes::prep()].
 #' @param history A tibble with the convergence statistics for
 #'  each term. This is `NULL` until the step is trained by
-#'  [recipes::prep.recipe()].
+#'  [recipes::prep()].
 #' @param skip A logical. Should the step be skipped when the
-#'  recipe is baked by [recipes::bake.recipe()]? While all
-#'  operations are baked when [recipes::prep.recipe()] is run, some
+#'  recipe is baked by [recipes::bake()]? While all
+#'  operations are baked when [recipes::prep()] is run, some
 #'  operations may not be able to be conducted on new data (e.g.
 #'  processing the outcome variable(s)). Care should be taken when
 #'  using `skip = TRUE` as it may affect the computations for

--- a/R/tf.R
+++ b/R/tf.R
@@ -110,6 +110,12 @@
 #'  session (via `foreach` or `futures`) or the `parallel` package.
 #'  If using a recipes with this step with `caret`, avoid parallel
 #'  processing.
+#'  
+#' # Tidying
+#'
+#' When you [`tidy()`][tidy.recipe()] this step, a tibble with columns
+#' `terms` (the selectors or variables selected), `levels` (levels in variable),
+#' and a number of columns with embedding information are returned.
 #'
 #' @references Francois C and Allaire JJ (2018)
 #' _Deep Learning with R_, Manning

--- a/R/umap.R
+++ b/R/umap.R
@@ -42,6 +42,11 @@
 #'  of numbers. The variable names are padded with zeros. For example, if
 #'  `num_comp < 10`, their names will be `UMAP1` - `UMAP9`. If `num_comp = 101`,
 #'  the names would be `UMAP001` - `UMAP101`.
+#'  
+#' # Tidying
+#'
+#' When you [`tidy()`][tidy.recipe()] this step, a tibble with columns
+#' `terms` (the selectors or variables selected) is returned.
 #'
 #' @references
 #' McInnes, L., & Healy, J. (2018). UMAP: Uniform Manifold Approximation and

--- a/R/umap.R
+++ b/R/umap.R
@@ -24,12 +24,12 @@
 #' @param seed Two integers to control the random numbers used by the
 #'  numerical methods. The default pulls from the main session's stream of
 #'  numbers and will give reproducible results if the seed is set prior to
-#'  calling [prep.recipe()] or [bake.recipe()].
+#'  calling [prep()] or [bake()].
 #' @param retain Use `keep_original_cols` instead to specify whether the
 #'  original predictors should be retained along with the new embedding
 #'  variables.
 #' @param object An object that defines the encoding. This is
-#'  `NULL` until the step is trained by [recipes::prep.recipe()].
+#'  `NULL` until the step is trained by [recipes::prep()].
 #' @template step-return
 #' @export
 #' @details

--- a/R/woe.R
+++ b/R/woe.R
@@ -63,6 +63,13 @@
 #' want to tweak this object with the goal to fix the orders between
 #' the levels of one given predictor. One easy way to do this is by
 #' tweaking an output returned from \code{dictionary()}.
+#' 
+#' # Tidying
+#'
+#' When you [`tidy()`][tidy.recipe()] this step, a tibble with columns
+#' `terms` (the selectors or variables selected), `value`, `n_tot`, `n_bad`,
+#' `n_good`, `p_bad`, `p_good`, `woe` and `outcome` is returned.. See 
+#' [dictionary()] for more information.
 #'
 #' @references Kullback, S. (1959). *Information Theory and Statistics.* Wiley, New York.
 #'

--- a/R/woe.R
+++ b/R/woe.R
@@ -441,11 +441,11 @@ tidy.step_woe <- function(x, ...) {
     res <- tibble(
       terms = term_names,
       value = rlang::na_chr,
-      ntot = rlang::na_int,
-      n_0 = rlang::na_int,
-      n_1 = rlang::na_int,
-      p_0 = rlang::na_dbl,
-      p_1 = rlang::na_dbl,
+      n_tot = rlang::na_int,
+      n_bad = rlang::na_int,
+      n_good = rlang::na_int,
+      p_bad = rlang::na_dbl,
+      p_good = rlang::na_dbl,
       woe = rlang::na_dbl
     )
   }

--- a/man/step_discretize_cart.Rd
+++ b/man/step_discretize_cart.Rd
@@ -51,8 +51,8 @@ splitting. Corresponds to \code{minsplit} in  \code{\link[rpart:rpart]{rpart::rp
 each variable. If length zero, splitting could not be used on that column.}
 
 \item{skip}{A logical. Should the step be skipped when the
-recipe is baked by \code{\link[recipes:bake]{recipes::bake.recipe()}}? While all operations are baked
-when \code{\link[recipes:prep]{recipes::prep.recipe()}} is run, some operations may not be able to be
+recipe is baked by \code{\link[recipes:bake]{recipes::bake()}}? While all operations are baked
+when \code{\link[recipes:prep]{recipes::prep()}} is run, some operations may not be able to be
 conducted on new data (e.g. processing the outcome variable(s)).
 Care should be taken when using \code{skip = TRUE} as it may affect
 the computations for subsequent operations}
@@ -107,5 +107,5 @@ bake(cart_rec, ad_data_te, tau)
 }
 \seealso{
 \code{\link[=step_discretize_xgb]{step_discretize_xgb()}}, \code{\link[recipes:recipe]{recipes::recipe()}},
-\code{\link[recipes:prep]{recipes::prep.recipe()}}, \code{\link[recipes:bake]{recipes::bake.recipe()}}
+\code{\link[recipes:prep]{recipes::prep()}}, \code{\link[recipes:bake]{recipes::bake()}}
 }

--- a/man/step_discretize_cart.Rd
+++ b/man/step_discretize_cart.Rd
@@ -84,6 +84,11 @@ step will stop with a note about installing the package.
 
 Note that the original data will be replaced with the new bins.
 }
+\section{Tidying}{
+When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with columns
+\code{terms} (the columns that is selected), \code{values} is returned.
+}
+
 \examples{
 library(modeldata)
 data(ad_data)

--- a/man/step_discretize_xgb.Rd
+++ b/man/step_discretize_xgb.Rd
@@ -104,6 +104,11 @@ step will stop with a note about installing the package.
 
 Note that the original data will be replaced with the new bins.
 }
+\section{Tidying}{
+When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with columns
+\code{terms} (the columns that is selected), \code{values} is returned.
+}
+
 \examples{
 library(modeldata)
 data(credit_data)

--- a/man/step_discretize_xgb.Rd
+++ b/man/step_discretize_xgb.Rd
@@ -60,8 +60,8 @@ Corresponds to \code{min_child_weight} in the \pkg{xgboost} package. Defaults to
 each variable.}
 
 \item{skip}{A logical. Should the step be skipped when the
-recipe is baked by \code{\link[recipes:bake]{recipes::bake.recipe()}}? While all operations are baked
-when \code{\link[recipes:prep]{recipes::prep.recipe()}} is run, some operations may not be able to be
+recipe is baked by \code{\link[recipes:bake]{recipes::bake()}}? While all operations are baked
+when \code{\link[recipes:prep]{recipes::prep()}} is run, some operations may not be able to be
 conducted on new data (e.g. processing the outcome variable(s)).
 Care should be taken when using \code{skip = TRUE} as it may affect
 the computations for subsequent operations}
@@ -128,5 +128,5 @@ if (rlang::is_installed("xgboost")) {
 }
 \seealso{
 \code{\link[=step_discretize_cart]{step_discretize_cart()}}, \code{\link[recipes:recipe]{recipes::recipe()}},
-\code{\link[recipes:prep]{recipes::prep.recipe()}}, \code{\link[recipes:bake]{recipes::bake.recipe()}}
+\code{\link[recipes:prep]{recipes::prep()}}, \code{\link[recipes:bake]{recipes::bake()}}
 }

--- a/man/step_embed.Rd
+++ b/man/step_embed.Rd
@@ -70,15 +70,15 @@ below).}
 
 \item{mapping}{A list of tibble results that define the
 encoding. This is \code{NULL} until the step is trained by
-\code{\link[recipes:prep]{recipes::prep.recipe()}}.}
+\code{\link[recipes:prep]{recipes::prep()}}.}
 
 \item{history}{A tibble with the convergence statistics for
 each term. This is \code{NULL} until the step is trained by
-\code{\link[recipes:prep]{recipes::prep.recipe()}}.}
+\code{\link[recipes:prep]{recipes::prep()}}.}
 
 \item{skip}{A logical. Should the step be skipped when the
-recipe is baked by \code{\link[recipes:bake]{recipes::bake.recipe()}}? While all
-operations are baked when \code{\link[recipes:prep]{recipes::prep.recipe()}} is run, some
+recipe is baked by \code{\link[recipes:bake]{recipes::bake()}}? While all
+operations are baked when \code{\link[recipes:prep]{recipes::prep()}} is run, some
 operations may not be able to be conducted on new data (e.g.
 processing the outcome variable(s)). Care should be taken when
 using \code{skip = TRUE} as it may affect the computations for

--- a/man/step_embed.Rd
+++ b/man/step_embed.Rd
@@ -161,6 +161,12 @@ session (via \code{foreach} or \code{futures}) or the \code{parallel} package.
 If using a recipes with this step with \code{caret}, avoid parallel
 processing.
 }
+\section{Tidying}{
+When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with columns
+\code{terms} (the selectors or variables selected), \code{levels} (levels in variable),
+and a number of columns with embedding information are returned.
+}
+
 \examples{
 library(modeldata)
 

--- a/man/step_feature_hash.Rd
+++ b/man/step_feature_hash.Rd
@@ -40,7 +40,7 @@ preprocessing have been estimated.}
 selected column(s) should be retained in addition to the new dummy variables.}
 
 \item{columns}{A character vector for the selected columns. This is \code{NULL}
-until the step is trained by \code{\link[recipes:prep]{recipes::prep.recipe()}}.}
+until the step is trained by \code{\link[recipes:prep]{recipes::prep()}}.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
 output. Defaults to \code{FALSE}.}

--- a/man/step_feature_hash.Rd
+++ b/man/step_feature_hash.Rd
@@ -82,6 +82,11 @@ it is likely that some columns will have all zeros. A zero-variance filter
 (via \code{\link[recipes:step_zv]{recipes::step_zv()}}) is recommended for any recipe that uses hashed
 columns.
 }
+\section{Tidying}{
+When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with columns
+\code{terms} (the columns that is selected)  is returned.
+}
+
 \examples{
 \donttest{
 data(grants, package = "modeldata")

--- a/man/step_lencode_bayes.Rd
+++ b/man/step_lencode_bayes.Rd
@@ -95,6 +95,12 @@ argument to the step. Relevant options include \code{chains}, \code{iter},
 References below). \code{prior_intercept} is the argument that has the
 most effect on the amount of shrinkage.
 }
+\section{Tidying}{
+When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with columns
+\code{terms} (the selectors or variables selected), \code{value} and \code{component} is
+returned.
+}
+
 \examples{
 library(recipes)
 library(dplyr)

--- a/man/step_lencode_bayes.Rd
+++ b/man/step_lencode_bayes.Rd
@@ -46,11 +46,11 @@ numeric and two-level factors are currently supported.}
 
 \item{mapping}{A list of tibble results that define the
 encoding. This is \code{NULL} until the step is trained by
-\code{\link[recipes:prep]{recipes::prep.recipe()}}.}
+\code{\link[recipes:prep]{recipes::prep()}}.}
 
 \item{skip}{A logical. Should the step be skipped when the
-recipe is baked by \code{\link[recipes:bake]{recipes::bake.recipe()}}? While all operations are baked
-when \code{\link[recipes:prep]{recipes::prep.recipe()}} is run, some operations may not be able to be
+recipe is baked by \code{\link[recipes:bake]{recipes::bake()}}? While all operations are baked
+when \code{\link[recipes:prep]{recipes::prep()}} is run, some operations may not be able to be
 conducted on new data (e.g. processing the outcome variable(s)).
 Care should be taken when using \code{skip = TRUE} as it may affect
 the computations for subsequent operations}

--- a/man/step_lencode_glm.Rd
+++ b/man/step_lencode_glm.Rd
@@ -76,6 +76,12 @@ interest being the \emph{first} level of the factor.
 For novel levels, a slightly timmed average of the coefficients
 is returned.
 }
+\section{Tidying}{
+When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with columns
+\code{terms} (the selectors or variables selected), \code{value} and \code{component} is
+returned.
+}
+
 \examples{
 library(recipes)
 library(dplyr)

--- a/man/step_lencode_glm.Rd
+++ b/man/step_lencode_glm.Rd
@@ -39,11 +39,11 @@ numeric and two-level factors are currently supported.}
 
 \item{mapping}{A list of tibble results that define the
 encoding. This is \code{NULL} until the step is trained by
-\code{\link[recipes:prep]{recipes::prep.recipe()}}.}
+\code{\link[recipes:prep]{recipes::prep()}}.}
 
 \item{skip}{A logical. Should the step be skipped when the
-recipe is baked by \code{\link[recipes:bake]{recipes::bake.recipe()}}? While all operations are baked
-when \code{\link[recipes:prep]{recipes::prep.recipe()}} is run, some operations may not be able to be
+recipe is baked by \code{\link[recipes:bake]{recipes::bake()}}? While all operations are baked
+when \code{\link[recipes:prep]{recipes::prep()}} is run, some operations may not be able to be
 conducted on new data (e.g. processing the outcome variable(s)).
 Care should be taken when using \code{skip = TRUE} as it may affect
 the computations for subsequent operations}

--- a/man/step_lencode_mixed.Rd
+++ b/man/step_lencode_mixed.Rd
@@ -90,6 +90,12 @@ set by the step) as well as any arguments given to the \code{options}
 argument to the step. Relevant options include \code{control} and
 others.
 }
+\section{Tidying}{
+When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with columns
+\code{terms} (the selectors or variables selected), \code{value} and \code{component} is
+returned.
+}
+
 \examples{
 library(recipes)
 library(dplyr)

--- a/man/step_lencode_mixed.Rd
+++ b/man/step_lencode_mixed.Rd
@@ -43,11 +43,11 @@ numeric and two-level factors are currently supported.}
 
 \item{mapping}{A list of tibble results that define the
 encoding. This is \code{NULL} until the step is trained by
-\code{\link[recipes:prep]{recipes::prep.recipe()}}.}
+\code{\link[recipes:prep]{recipes::prep()}}.}
 
 \item{skip}{A logical. Should the step be skipped when the
-recipe is baked by \code{\link[recipes:bake]{recipes::bake.recipe()}}? While all operations are baked
-when \code{\link[recipes:prep]{recipes::prep.recipe()}} is run, some operations may not be able to be
+recipe is baked by \code{\link[recipes:bake]{recipes::bake()}}? While all operations are baked
+when \code{\link[recipes:prep]{recipes::prep()}} is run, some operations may not be able to be
 conducted on new data (e.g. processing the outcome variable(s)).
 Care should be taken when using \code{skip = TRUE} as it may affect
 the computations for subsequent operations}

--- a/man/step_pca_sparse.Rd
+++ b/man/step_pca_sparse.Rd
@@ -50,7 +50,7 @@ non-zero coefficients for each PCA component (via regularization).}
 \item{options}{A list of options to the default method for \code{\link[irlba:ssvd]{irlba::ssvd()}}.}
 
 \item{res}{The rotation matrix once this
-preprocessing step has be trained by \code{\link[=prep.recipe]{prep.recipe()}}.}
+preprocessing step has be trained by \code{\link[=prep]{prep()}}.}
 
 \item{prefix}{A character string that will be the prefix to the resulting
 new variables. See notes below.}
@@ -59,8 +59,8 @@ new variables. See notes below.}
 output. Defaults to \code{FALSE}.}
 
 \item{skip}{A logical. Should the step be skipped when the
-recipe is baked by \code{\link[recipes:bake]{recipes::bake.recipe()}}? While all operations are baked
-when \code{\link[recipes:prep]{recipes::prep.recipe()}} is run, some operations may not be able to be
+recipe is baked by \code{\link[recipes:bake]{recipes::bake()}}? While all operations are baked
+when \code{\link[recipes:prep]{recipes::prep()}} is run, some operations may not be able to be
 conducted on new data (e.g. processing the outcome variable(s)).
 Care should be taken when using \code{skip = TRUE} as it may affect
 the computations for subsequent operations}

--- a/man/step_pca_sparse.Rd
+++ b/man/step_pca_sparse.Rd
@@ -94,6 +94,12 @@ if \code{num_comp < 10}, their names will be \code{PC1} - \code{PC9}.
 If \code{num_comp = 101}, the names would be \code{PC001} -
 \code{PC101}.
 }
+\section{Tidying}{
+When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with columns
+\code{terms} (the selectors or variables selected), \code{value} and \code{component} is
+returned.
+}
+
 \examples{
 library(recipes)
 library(ggplot2)

--- a/man/step_pca_sparse_bayes.Rd
+++ b/man/step_pca_sparse_bayes.Rd
@@ -112,6 +112,12 @@ if \code{num_comp < 10}, their names will be \code{PC1} - \code{PC9}.
 If \code{num_comp = 101}, the names would be \code{PC001} -
 \code{PC101}.
 }
+\section{Tidying}{
+When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with columns
+\code{terms} (the selectors or variables selected), \code{value} and \code{component} is
+returned.
+}
+
 \examples{
 library(recipes)
 library(ggplot2)

--- a/man/step_pca_sparse_bayes.Rd
+++ b/man/step_pca_sparse_bayes.Rd
@@ -56,7 +56,7 @@ increases the number of zero coefficients.}
 \code{\link[VBsparsePCA:VBsparsePCA]{VBsparsePCA::VBsparsePCA()}}.}
 
 \item{res}{The rotation matrix once this preprocessing step has been trained
-by \code{\link[=prep.recipe]{prep.recipe()}}.}
+by \code{\link[=prep]{prep()}}.}
 
 \item{prefix}{A character string that will be the prefix to the resulting
 new variables. See notes below.}
@@ -65,8 +65,8 @@ new variables. See notes below.}
 output. Defaults to \code{FALSE}.}
 
 \item{skip}{A logical. Should the step be skipped when the
-recipe is baked by \code{\link[recipes:bake]{recipes::bake.recipe()}}? While all operations are baked
-when \code{\link[recipes:prep]{recipes::prep.recipe()}} is run, some operations may not be able to be
+recipe is baked by \code{\link[recipes:bake]{recipes::bake()}}? While all operations are baked
+when \code{\link[recipes:prep]{recipes::prep()}} is run, some operations may not be able to be
 conducted on new data (e.g. processing the outcome variable(s)).
 Care should be taken when using \code{skip = TRUE} as it may affect
 the computations for subsequent operations}

--- a/man/step_umap.Rd
+++ b/man/step_umap.Rd
@@ -69,7 +69,7 @@ process.}
 \item{seed}{Two integers to control the random numbers used by the
 numerical methods. The default pulls from the main session's stream of
 numbers and will give reproducible results if the seed is set prior to
-calling \code{\link[=prep.recipe]{prep.recipe()}} or \code{\link[=bake.recipe]{bake.recipe()}}.}
+calling \code{\link[=prep]{prep()}} or \code{\link[=bake]{bake()}}.}
 
 \item{prefix}{A character string for the prefix of the resulting new
 variables. See notes below.}
@@ -82,7 +82,7 @@ original predictors should be retained along with the new embedding
 variables.}
 
 \item{object}{An object that defines the encoding. This is
-\code{NULL} until the step is trained by \code{\link[recipes:prep]{recipes::prep.recipe()}}.}
+\code{NULL} until the step is trained by \code{\link[recipes:prep]{recipes::prep()}}.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[recipes:bake]{bake()}}? While all operations are baked

--- a/man/step_umap.Rd
+++ b/man/step_umap.Rd
@@ -114,6 +114,11 @@ of numbers. The variable names are padded with zeros. For example, if
 \code{num_comp < 10}, their names will be \code{UMAP1} - \code{UMAP9}. If \code{num_comp = 101},
 the names would be \code{UMAP001} - \code{UMAP101}.
 }
+\section{Tidying}{
+When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with columns
+\code{terms} (the selectors or variables selected) is returned.
+}
+
 \examples{
 library(recipes)
 library(ggplot2)

--- a/man/step_woe.Rd
+++ b/man/step_woe.Rd
@@ -53,8 +53,8 @@ Also known as 'pseudocount' parameter of the Laplace smoothing technique.}
 resulting new variables. See notes below.}
 
 \item{skip}{A logical. Should the step be skipped when the
-recipe is baked by \code{\link[recipes:bake]{recipes::bake.recipe()}}? While all operations are baked
-when \code{\link[recipes:prep]{recipes::prep.recipe()}} is run, some operations may not be able to be
+recipe is baked by \code{\link[recipes:bake]{recipes::bake()}}? While all operations are baked
+when \code{\link[recipes:prep]{recipes::prep()}} is run, some operations may not be able to be
 conducted on new data (e.g. processing the outcome variable(s)).
 Care should be taken when using \code{skip = TRUE} as it may affect
 the computations for subsequent operations}

--- a/man/step_woe.Rd
+++ b/man/step_woe.Rd
@@ -105,6 +105,13 @@ want to tweak this object with the goal to fix the orders between
 the levels of one given predictor. One easy way to do this is by
 tweaking an output returned from \code{dictionary()}.
 }
+\section{Tidying}{
+When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with columns
+\code{terms} (the selectors or variables selected), \code{value}, \code{n_tot}, \code{n_bad},
+\code{n_good}, \code{p_bad}, \code{p_good}, \code{woe} and \code{outcome} is returned.. See
+\code{\link[=dictionary]{dictionary()}} for more information.
+}
+
 \examples{
 library(modeldata)
 data("credit_data")


### PR DESCRIPTION
This PR aims to close https://github.com/tidymodels/embed/issues/105.

It adds a `# Tidying` section to the documentation of each step, similarly to how it was done in https://github.com/tidymodels/recipes/pull/895.