### PR TITLE
have woe_table respect factor levels of outcome

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Reorganize documentation for all recipe step `tidy` methods (#115).
 
+* Fixed a bug where `woe_table()` and `step_woe()` didn't respect the factor levels of the outcome. (109)
+
 # embed 0.1.5
 
 * Re-licensed package from GPL-2 to MIT. See [consent from copyright holders here](https://github.com/tidymodels/embed/issues/78).

--- a/R/woe.R
+++ b/R/woe.R
@@ -175,7 +175,11 @@ step_woe_new <- function(terms, role, trained, outcome, dictionary, Laplace, pre
 #'
 #' Good, I. J. (1985), "Weight of evidence: A brief survey", _Bayesian Statistics_, 2, pp.249-270.
 woe_table <- function(predictor, outcome, Laplace = 1e-6) {
-  outcome_original_labels <- unique(outcome)
+  if (is.factor(outcome)) {
+    outcome_original_labels <- levels(outcome)
+  } else {
+    outcome_original_labels <- unique(outcome)
+  }
 
   if (length(outcome_original_labels) != 2) {
     rlang::abort(sprintf(

--- a/tests/testthat/test_woe.R
+++ b/tests/testthat/test_woe.R
@@ -240,6 +240,24 @@ test_that("2-level factors", {
   )
 })
 
+test_that("woe_table respects factor levels", {
+  dat <- tibble(
+    predictor  = sample(0:1, 100, TRUE),
+    target = factor(predictor == 0, levels = c(TRUE, FALSE), labels = 0:1),
+    target0 = relevel(target, ref = "0"),
+    target1 = relevel(target, ref = "1")
+  ) 
+  
+  expect_equal(
+    woe_table(dat$predictor, dat$target0)$woe,
+    -woe_table(dat$predictor, dat$target1)$woe
+  )
+  
+  expect_identical(
+    woe_table(dat$predictor, dat$target0) %>% select(-woe),
+    woe_table(dat$predictor, dat$target1) %>% select(-woe)
+  )
+})
 
 # ------------------------------------------------------------------------------
 
@@ -257,3 +275,4 @@ test_that("empty selections", {
     ad_data %>% select(Genotype, tau, Class)
   )
 })
+


### PR DESCRIPTION
This PR aims to close https://github.com/tidymodels/embed/issues/109.

Very minor change, uses `levels()` if outcome is a factor, `unique()` otherwise. It would have been a breaking change to assume that outcome would be a factor.