### PR TITLE
Add more flexibility for use of family in step_lencode_* steps

### DIFF
--- a/R/bayes.R
+++ b/R/bayes.R
@@ -58,10 +58,10 @@
 #' ```
 #'
 #' where the `...` include the `family` argument (automatically
-#'  set by the step) as well as any arguments given to the `options`
-#'  argument to the step. Relevant options include `chains`, `iter`,
-#'  `cores`, and arguments for the priors (see the links in the
-#'  References below). `prior_intercept` is the argument that has the
+#'  set by the step, unless passed in by `options`) as well as any arguments 
+#'  given to the `options` argument to the step. Relevant options include 
+#'  `chains`, `iter`, `cores`, and arguments for the priors (see the links 
+#'  in the References below). `prior_intercept` is the argument that has the
 #'  most effect on the amount of shrinkage.
 #' 
 #' # Tidying
@@ -178,11 +178,17 @@ prep.step_lencode_bayes <- function(x, training, info = NULL, ...) {
 
 stan_coefs <- function(x, y, options, verbose, ...) {
   rlang::check_installed("rstanarm")
-  if (is.factor(y[[1]])) {
-    fam <- binomial()
+  if (is.null(options$family)) {
+    if (is.factor(y[[1]])) {
+      fam <- binomial()
+    } else {
+      fam <- gaussian()
+    }
   } else {
-    fam <- gaussian()
+    fam <- options$family
+    options$family <- NULL
   }
+  
   form <- as.formula(paste0(names(y), "~ (1|value)"))
 
   if (is.vector(x) | is.factor(x)) {

--- a/R/lme.R
+++ b/R/lme.R
@@ -179,18 +179,16 @@ lme_coefs <- function(x, y, ...) {
   if (length(dots) > 0) {
     args <- c(args, dots[[1]])
   }
-
-  if (!is.factor(y[[1]])) {
-    cl <- rlang::call2("lmer", .ns = "lme4", !!!args)
-    mod <- rlang::eval_tidy(cl)
-  } else {
+  
+  if (is.factor(y[[1]])) {
     args$data$y <- as.numeric(args$data$y) - 1
     if (is.null(args$family)) {
       args$family <- stats::binomial
     }
-    cl <- rlang::call2("glmer", .ns = "lme4", !!!args)
-    mod <- rlang::eval_tidy(cl)
   }
+  
+  cl <- rlang::call2("glmer", .ns = "lme4", !!!args)
+  mod <- rlang::eval_tidy(cl)
 
   coefs <- coef(mod)$value
   ..levels <- rownames(coefs)

--- a/R/lme.R
+++ b/R/lme.R
@@ -185,7 +185,9 @@ lme_coefs <- function(x, y, ...) {
     mod <- rlang::eval_tidy(cl)
   } else {
     args$data$y <- as.numeric(args$data$y) - 1
-    args$family <- stats::binomial
+    if (is.null(args$family)) {
+      args$family <- stats::binomial
+    }
     cl <- rlang::call2("glmer", .ns = "lme4", !!!args)
     mod <- rlang::eval_tidy(cl)
   }

--- a/man/step_lencode_bayes.Rd
+++ b/man/step_lencode_bayes.Rd
@@ -84,10 +84,10 @@ A hierarchical generalized linear model is fit using
 }
 
 where the \code{...} include the \code{family} argument (automatically
-set by the step) as well as any arguments given to the \code{options}
-argument to the step. Relevant options include \code{chains}, \code{iter},
-\code{cores}, and arguments for the priors (see the links in the
-References below). \code{prior_intercept} is the argument that has the
+set by the step, unless passed in by \code{options}) as well as any arguments
+given to the \code{options} argument to the step. Relevant options include
+\code{chains}, \code{iter}, \code{cores}, and arguments for the priors (see the links
+in the References below). \code{prior_intercept} is the argument that has the
 most effect on the amount of shrinkage.
 }
 \section{Tidying}{

--- a/tests/testthat/_snaps/pooling.md
+++ b/tests/testthat/_snaps/pooling.md
@@ -66,3 +66,21 @@
         retain = TRUE)
     Condition
 
+# Works with passing family 
+
+    Code
+      class_test <- recipe(outcome ~ ., data = ex_dat_poisson) %>% step_lencode_bayes(
+        x3, outcome = vars(outcome), verbose = FALSE, options = c(opts, family = stats::poisson)) %>%
+        prep(training = ex_dat_poisson, retain = TRUE)
+    Condition
+
+---
+
+    Code
+      new_values_ch <- bake(class_test, new_data = new_dat_ch)
+    Condition
+      Warning:
+       There was 1 column that was a factor when the recipe was prepped:
+       'x3'.
+       This may cause errors when processing new data.
+

--- a/tests/testthat/test_pooling.R
+++ b/tests/testthat/test_pooling.R
@@ -290,7 +290,80 @@ test_that("character encoded predictor", {
   )
 })
 
+# ------------------------------------------------------------------------------
 
+
+test_that("Works with passing family ", {
+  skip_on_cran()
+  skip_if_not_installed("rstanarm")
+  
+  ex_dat_poisson <- ex_dat %>%
+    mutate(outcome = rpois(n(), 5))
+  
+  expect_snapshot(
+    transform = omit_warning("^(Bulk Effective|Tail Effective)"),
+    {
+      class_test <- recipe(outcome ~ ., data = ex_dat_poisson) %>%
+        step_lencode_bayes(x3,
+                           outcome = vars(outcome),
+                           verbose = FALSE,
+                           options = c(opts, family = stats::poisson)
+        ) %>%
+        prep(training = ex_dat_poisson, retain = TRUE)
+    }
+  )
+  tr_values <- juice(class_test)$x3
+  new_values <- bake(class_test, new_data = new_dat)
+  expect_snapshot(
+    new_values_ch <- bake(class_test, new_data = new_dat_ch)
+  )
+  key <- class_test$steps[[1]]$mapping
+  td_obj <- tidy(class_test, number = 1)
+  
+  expect_equal("x3", names(key))
+  
+  expect_equal(
+    length(unique(ex_dat$x3)) + 1,
+    nrow(key$x3)
+  )
+  expect_true(sum(key$x3$..level == "..new") == 1)
+  
+  expect_true(is.numeric(tr_values))
+  
+  expect_equal(
+    new_values$x3[1],
+    key$x3$..value[key$x3$..level == "..new"]
+  )
+  expect_equal(
+    new_values$x3[2],
+    key$x3$..value[key$x3$..level == levels(ex_dat$x3)[1]]
+  )
+  expect_equal(
+    new_values$x3[3],
+    key$x3$..value[key$x3$..level == "..new"]
+  )
+  expect_equal(
+    new_values_ch$x3[1],
+    key$x3$..value[key$x3$..level == "..new"]
+  )
+  expect_equal(
+    new_values_ch$x3[2],
+    key$x3$..value[key$x3$..level == levels(ex_dat$x3)[1]]
+  )
+  expect_equal(
+    new_values_ch$x3[3],
+    key$x3$..value[key$x3$..level == "..new"]
+  )
+  
+  expect_equal(
+    td_obj$level,
+    key$x3$..level
+  )
+  expect_equal(
+    td_obj$value,
+    key$x3$..value
+  )
+})
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR aims to close https://github.com/tidymodels/embed/issues/122.

`step_lencode_bayes()` now allows the user to pass in `family` in `options` and `step_lencode_mixed()` globally uses `lme4::glmer()` and allow user supplied `family` to overwrite.