### PR TITLE
don't end with as_tibble in bake functions

### DIFF
--- a/R/discretize_cart.R
+++ b/R/discretize_cart.R
@@ -237,7 +237,7 @@ bake.step_discretize_cart <- function(object, new_data, ...) {
       new_data <- binned_data
     }
   }
-  tibble::as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/discretize_xgb.R
+++ b/R/discretize_xgb.R
@@ -444,7 +444,7 @@ bake.step_discretize_xgb <- function(object, new_data, ...) {
       new_data <- binned_data
     }
   }
-  tibble::as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/pca_sparse.R
+++ b/R/pca_sparse.R
@@ -198,7 +198,7 @@ bake.step_pca_sparse <- function(object, new_data, ...) {
       new_data <- new_data[, !(colnames(new_data) %in% pca_vars), drop = FALSE]
     }
   }
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/pca_sparse_bayes.R
+++ b/R/pca_sparse_bayes.R
@@ -225,7 +225,7 @@ bake.step_pca_sparse_bayes <- function(object, new_data, ...) {
       new_data <- new_data[, !(colnames(new_data) %in% pca_vars), drop = FALSE]
     }
   }
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/woe.R
+++ b/R/woe.R
@@ -427,7 +427,7 @@ bake.step_woe <- function(object, new_data, ...) {
     prefix = object$prefix
   )
   new_data <- new_data[, !(colnames(new_data) %in% woe_vars), drop = FALSE]
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export


### PR DESCRIPTION
Since `bake.recipe()` calls `as_tibble()` after each step we don't need to do it inside each step.