### PR TITLE
Add method and options argument to step_collapse_stringdist()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * All steps now have `required_pkgs()` methods.
 
+* `step_collapse_stringdist()` has gained `method` and `options` arguments to allow for different types of string distance calculations. (#619)
+
 # embed 1.0.0
 
 * `step_collapse_cart()` can pool a predictor's factor levels using a tree-based method. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * All steps now have `required_pkgs()` methods.
 
-* `step_collapse_stringdist()` has gained `method` and `options` arguments to allow for different types of string distance calculations. (#619)
+* `step_collapse_stringdist()` has gained `method` and `options` arguments to allow for different types of string distance calculations. (#152)
 
 # embed 1.0.0
 

--- a/R/collapse_stringdist.R
+++ b/R/collapse_stringdist.R
@@ -11,6 +11,8 @@
 #' @param distance Integer, value to determine which strings should be collapsed
 #'   with which. The value is being used inclusive, so `2` will collapse levels
 #'   that have a string distance between them of 2 or lower.
+#' @param method Character, method for distance calculation. The default is 
+#'   `"osa"`, see [stringdist::stringdist-metrics].
 #' @param results A list denoting the way the labels should be collapses is
 #'   stored here once this preprocessing step has be trained by [prep()].
 #' @param columns A character string of variable names that will be populated
@@ -61,6 +63,7 @@ step_collapse_stringdist <-
            role = NA,
            trained = FALSE,
            distance = NULL,
+           method = "osa",
            results = NULL,
            columns = NULL,
            skip = FALSE,
@@ -76,6 +79,7 @@ step_collapse_stringdist <-
         role = role,
         trained = trained,
         distance = distance,
+        method = method,
         results = results,
         columns = columns,
         skip = skip,
@@ -85,13 +89,14 @@ step_collapse_stringdist <-
   }
 
 step_collapse_stringdist_new <-
-  function(terms, role, trained, distance, results, columns, skip, id) {
+  function(terms, role, trained, distance, method, results, columns, skip, id) {
     step(
       subclass = "collapse_stringdist",
       terms = terms,
       role = role,
       trained = trained,
       distance = distance,
+      method = method,
       results = results,
       columns = columns,
       skip = skip,
@@ -103,13 +108,19 @@ step_collapse_stringdist_new <-
 prep.step_collapse_stringdist <- function(x, training, info = NULL, ...) {
   col_names <- recipes_eval_select(x$terms, training, info)
 
-  values <- lapply(training[, col_names], collapse_stringdist_impl, x$distance)
+  values <- lapply(
+    training[, col_names],
+    collapse_stringdist_impl, 
+    dist = x$distance,
+    method = x$method
+  )
 
   step_collapse_stringdist_new(
     terms = x$terms,
     role = x$role,
     trained = TRUE,
     distance = x$distance,
+    method = x$method,
     results = values,
     columns = col_names,
     skip = x$skip,
@@ -117,13 +128,13 @@ prep.step_collapse_stringdist <- function(x, training, info = NULL, ...) {
   )
 }
 
-collapse_stringdist_impl <- function(x, dist) {
+collapse_stringdist_impl <- function(x, dist, method) {
   if (is.factor(x)) {
     x <- levels(x)
   } else {
     x <- unique(x)
   }
-  dists <- stringdist::stringdistmatrix(x, x)
+  dists <- stringdist::stringdistmatrix(x, x, method = method)
 
   pairs <- which(dists <= dist, arr.ind = TRUE)
 

--- a/man/step_collapse_stringdist.Rd
+++ b/man/step_collapse_stringdist.Rd
@@ -10,6 +10,7 @@ step_collapse_stringdist(
   role = NA,
   trained = FALSE,
   distance = NULL,
+  method = "osa",
   results = NULL,
   columns = NULL,
   skip = FALSE,
@@ -32,6 +33,9 @@ preprocessing have been estimated.}
 \item{distance}{Integer, value to determine which strings should be collapsed
 with which. The value is being used inclusive, so \code{2} will collapse levels
 that have a string distance between them of 2 or lower.}
+
+\item{method}{Character, method for distance calculation. The default is
+\code{"osa"}, see \link[stringdist:stringdist-metrics]{stringdist::stringdist-metrics}.}
 
 \item{results}{A list denoting the way the labels should be collapses is
 stored here once this preprocessing step has be trained by \code{\link[=prep]{prep()}}.}

--- a/man/step_collapse_stringdist.Rd
+++ b/man/step_collapse_stringdist.Rd
@@ -11,6 +11,7 @@ step_collapse_stringdist(
   trained = FALSE,
   distance = NULL,
   method = "osa",
+  options = list(),
   results = NULL,
   columns = NULL,
   skip = FALSE,
@@ -36,6 +37,10 @@ that have a string distance between them of 2 or lower.}
 
 \item{method}{Character, method for distance calculation. The default is
 \code{"osa"}, see \link[stringdist:stringdist-metrics]{stringdist::stringdist-metrics}.}
+
+\item{options}{List, other arguments passed to
+\code{\link[stringdist:stringdist]{stringdist::stringdistmatrix()}} such as \code{weight}, \code{q}, \code{p}, and \code{bt}, that
+are used for different values of \code{method}.}
 
 \item{results}{A list denoting the way the labels should be collapses is
 stored here once this preprocessing step has be trained by \code{\link[=prep]{prep()}}.}

--- a/tests/testthat/test_collapse_stringdist.R
+++ b/tests/testthat/test_collapse_stringdist.R
@@ -86,6 +86,46 @@ test_that("collapsing factors manual test", {
   )
 })
 
+test_that("method argument", {
+  data0 <- tibble(
+    x1 = c("a", "b", "d", "e", "aaaaaa", "bbbbbb"),
+    x2 = c("ak", "b", "djj", "e", "aaaaaa", "aaaaaa")
+  )
+  
+  rec <- recipe(~., data = data0) %>%
+    step_collapse_stringdist(
+      all_predictors(), 
+      distance = 0.5, method = "cosine"
+    ) %>%
+    prep()
+  
+  exp_result <- tibble(
+    x1 = factor(c("a", "b", "d", "e", "a", "b")),
+    x2 = factor(c("aaaaaa", "b", "djj", "e", "aaaaaa", "aaaaaa"))
+  )
+  expect_equal(
+    bake(rec, new_data = NULL),
+    exp_result
+  )
+  
+  rec <- recipe(~., data = data0) %>%
+    step_collapse_stringdist(
+      all_predictors(), 
+      distance = 1, method = "cosine"
+    ) %>%
+    prep()
+  
+  exp_result <- tibble(
+    x1 = factor(c("a", "a", "a", "a", "a", "a")),
+    x2 = factor(c("aaaaaa", "aaaaaa", "aaaaaa", "aaaaaa", "aaaaaa", "aaaaaa"))
+  )
+  expect_equal(
+    bake(rec, new_data = NULL),
+    exp_result
+  )
+})
+
+
 test_that("failed collapsing", {
   skip_if_not_installed("modeldata")
   data(ames, package = "modeldata")

--- a/tests/testthat/test_collapse_stringdist.R
+++ b/tests/testthat/test_collapse_stringdist.R
@@ -125,6 +125,30 @@ test_that("method argument", {
   )
 })
 
+test_that("options argument", {
+  data0 <- tibble(
+    x1 = c("a", "b", "d", "e", "aaaaaa", "bbbbbb"),
+    x2 = c("ak", "b", "djj", "e", "aaaaaa", "aaaaaa")
+  )
+  
+  rec <- recipe(~., data = data0) %>%
+    step_collapse_stringdist(
+      all_predictors(), 
+      distance = 1, 
+      options = list(weight = c(d = 0.1, i = 1, s = 1, t = 1))
+    ) %>%
+    prep()
+  
+  exp_result <- tibble(
+    x1 = factor(c("a", "a", "a", "a", "a", "b")),
+    x2 = factor(c("ak", "b", "djj", "b", "aaaaaa", "aaaaaa"))
+  )
+  expect_equal(
+    bake(rec, new_data = NULL),
+    exp_result
+  )
+})
+
 
 test_that("failed collapsing", {
   skip_if_not_installed("modeldata")


### PR DESCRIPTION
To close https://github.com/tidymodels/embed/issues/152

``` r
library(embed)

data0 <- tibble(
  x1 = c("a", "b", "d", "e", "sfgsfgsd", "hjhgfgjgr"),
  x2 = c("ak", "b", "djj", "e", "hjhgfgjgr", "hjhgfgjgr")
)

recipe(~., data = data0) %>%
  step_collapse_stringdist(all_predictors(), method = 'jw', distance = 0.1) %>%
  prep() %>%
  bake(new_data = NULL)
#> # A tibble: 6 × 2
#>   x1        x2       
#>   <fct>     <fct>    
#> 1 a         ak       
#> 2 b         b        
#> 3 d         djj      
#> 4 e         e        
#> 5 sfgsfgsd  hjhgfgjgr
#> 6 hjhgfgjgr hjhgfgjgr
```

<sup>Created on 2023-03-15 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>