### PR TITLE
Refactor documentation of num_comp argument

### DIFF
--- a/R/pca_sparse.R
+++ b/R/pca_sparse.R
@@ -38,12 +38,11 @@
 #' function is used to encourage sparsity; that documentation has details about
 #' this method.
 #'
-#' The argument `num_comp` controls the number of components that will be
-#' retained (per default the original variables that are used to derive the
-#' components are removed from the data). The new components will have names
-#' that begin with `prefix` and a sequence of numbers. The variable names are
-#' padded with zeros. For example, if `num_comp < 10`, their names will be `PC1`
-#' - `PC9`. If `num_comp = 101`, the names would be `PC001` - `PC101`.
+#' ```{r, echo = FALSE, results="asis"}
+#' prefix <- "PC"
+#' result <- knitr::knit_child("man/rmd/num_comp.Rmd")
+#' cat(result)
+#' ```
 #'
 #' # Tidying
 #'

--- a/R/pca_sparse_bayes.R
+++ b/R/pca_sparse_bayes.R
@@ -57,12 +57,11 @@
 #' from run-to-run. However, the sparsity constraint may interfere with this
 #' goal.
 #'
-#' The argument `num_comp` controls the number of components that will be
-#' retained (per default the original variables that are used to derive the
-#' components are removed from the data). The new components will have names
-#' that begin with `prefix` and a sequence of numbers. The variable names are
-#' padded with zeros. For example, if `num_comp < 10`, their names will be `PC1`
-#' - `PC9`. If `num_comp = 101`, the names would be `PC001` - `PC101`.
+#' ```{r, echo = FALSE, results="asis"}
+#' prefix <- "PC"
+#' result <- knitr::knit_child("man/rmd/num_comp.Rmd")
+#' cat(result)
+#' ```
 #'
 #' # Tidying
 #'

--- a/R/pca_truncated.R
+++ b/R/pca_truncated.R
@@ -27,13 +27,12 @@
 #' be changed using the `options` argument or by using [step_center()] and
 #' [step_scale()].
 #'
-#' The argument `num_comp` controls the number of components that will be
-#' retained (the original variables that are used to derive the components are
-#' removed from the data). The new components will have names that begin with
-#' `prefix` and a sequence of numbers. The variable names are padded with zeros.
-#' For example, if `num_comp < 10`, their names will be `PC1` - `PC9`. If
-#' `num_comp = 101`, the names would be `PC001` - `PC101`.
-#'
+#' ```{r, echo = FALSE, results="asis"}
+#' prefix <- "PC"
+#' result <- knitr::knit_child("man/rmd/num_comp.Rmd")
+#' cat(result)
+#' ```
+#' 
 #' # Tidying
 #'
 #' When you [`tidy()`][tidy.recipe()] this step, use either `type = "coef"` for

--- a/R/umap.R
+++ b/R/umap.R
@@ -41,10 +41,11 @@
 #' representations of the data. It can be run unsupervised or supervised with
 #' different types of outcome data (e.g. numeric, factor, etc).
 #'
-#' The new components will have names that begin with `prefix` and a sequence of
-#' numbers. The variable names are padded with zeros. For example, if `num_comp
-#' < 10`, their names will be `UMAP1` - `UMAP9`. If `num_comp = 101`, the names
-#' would be `UMAP001` - `UMAP101`.
+#' ```{r, echo = FALSE, results="asis"}
+#' prefix <- "UMAP"
+#' result <- knitr::knit_child("man/rmd/num_comp.Rmd")
+#' cat(result)
+#' ```
 #'
 #' # Tidying
 #'

--- a/man/rmd/num_comp.Rmd
+++ b/man/rmd/num_comp.Rmd
@@ -1,0 +1,11 @@
+```{r, include = FALSE}
+low_range <- paste0("\`", prefix, 1, "\` - \`", prefix, 9, "\`")
+high_range <- paste0("\`", prefix, 001, "\` - \`", prefix, 101, "\`")
+```
+
+The argument `num_comp` controls the number of components that will be retained
+(the original variables that are used to derive the components are removed from
+the data). The new components will have names that begin with `prefix` and a 
+sequence of numbers. The variable names are padded with zeros. For example, if 
+`num_comp < 10`, their names will be `r low_range`. If `num_comp = 101`, 
+the names would be `r high_range`.

--- a/man/step_pca_sparse.Rd
+++ b/man/step_pca_sparse.Rd
@@ -79,14 +79,12 @@ user will be prompted to do so when the step is defined. The \code{\link[irlba:s
 function is used to encourage sparsity; that documentation has details about
 this method.
 
-The argument \code{num_comp} controls the number of components that will be
-retained (per default the original variables that are used to derive the
-components are removed from the data). The new components will have names
-that begin with \code{prefix} and a sequence of numbers. The variable names are
-padded with zeros. For example, if \code{num_comp < 10}, their names will be \code{PC1}
-\itemize{
-\item \code{PC9}. If \code{num_comp = 101}, the names would be \code{PC001} - \code{PC101}.
-}
+The argument \code{num_comp} controls the number of components that will be retained
+(the original variables that are used to derive the components are removed from
+the data). The new components will have names that begin with \code{prefix} and a
+sequence of numbers. The variable names are padded with zeros. For example, if
+\code{num_comp < 10}, their names will be \code{PC1} - \code{PC9}. If \code{num_comp = 101},
+the names would be \code{PC1} - \code{PC101}.
 }
 \section{Tidying}{
 When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with columns \code{terms}

--- a/man/step_pca_sparse_bayes.Rd
+++ b/man/step_pca_sparse_bayes.Rd
@@ -98,14 +98,12 @@ This step will attempt to make the sign of the components more consistent
 from run-to-run. However, the sparsity constraint may interfere with this
 goal.
 
-The argument \code{num_comp} controls the number of components that will be
-retained (per default the original variables that are used to derive the
-components are removed from the data). The new components will have names
-that begin with \code{prefix} and a sequence of numbers. The variable names are
-padded with zeros. For example, if \code{num_comp < 10}, their names will be \code{PC1}
-\itemize{
-\item \code{PC9}. If \code{num_comp = 101}, the names would be \code{PC001} - \code{PC101}.
-}
+The argument \code{num_comp} controls the number of components that will be retained
+(the original variables that are used to derive the components are removed from
+the data). The new components will have names that begin with \code{prefix} and a
+sequence of numbers. The variable names are padded with zeros. For example, if
+\code{num_comp < 10}, their names will be \code{PC1} - \code{PC9}. If \code{num_comp = 101},
+the names would be \code{PC1} - \code{PC101}.
 }
 \section{Tidying}{
 When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with columns \code{terms}

--- a/man/step_pca_truncated.Rd
+++ b/man/step_pca_truncated.Rd
@@ -47,8 +47,8 @@ argument \code{x} should not be passed here (or at all).}
 \item{res}{The \code{\link[irlba:prcomp_irlba]{irlba::prcomp_irlba()}} object is stored here once this
 preprocessing step has be trained by \code{\link[=prep]{prep()}}.}
 
-\item{columns}{A character string of the selected variable names. This field
-is a placeholder and will be populated once \code{\link[recipes:prep]{prep()}} is used.}
+\item{columns}{A character string of variable names that will
+be populated elsewhere.}
 
 \item{prefix}{A character string for the prefix of the resulting new
 variables. See notes below.}
@@ -88,12 +88,12 @@ variable will be centered and scaled prior to the PCA calculation. This can
 be changed using the \code{options} argument or by using \code{\link[=step_center]{step_center()}} and
 \code{\link[=step_scale]{step_scale()}}.
 
-The argument \code{num_comp} controls the number of components that will be
-retained (the original variables that are used to derive the components are
-removed from the data). The new components will have names that begin with
-\code{prefix} and a sequence of numbers. The variable names are padded with zeros.
-For example, if \code{num_comp < 10}, their names will be \code{PC1} - \code{PC9}. If
-\code{num_comp = 101}, the names would be \code{PC001} - \code{PC101}.
+The argument \code{num_comp} controls the number of components that will be retained
+(the original variables that are used to derive the components are removed from
+the data). The new components will have names that begin with \code{prefix} and a
+sequence of numbers. The variable names are padded with zeros. For example, if
+\code{num_comp < 10}, their names will be \code{PC1} - \code{PC9}. If \code{num_comp = 101},
+the names would be \code{PC1} - \code{PC101}.
 }
 \section{Tidying}{
 When you \code{\link[=tidy.recipe]{tidy()}} this step, use either \code{type = "coef"} for

--- a/man/step_umap.Rd
+++ b/man/step_umap.Rd
@@ -109,9 +109,12 @@ dimension reduction technique that finds local, low-dimensional
 representations of the data. It can be run unsupervised or supervised with
 different types of outcome data (e.g. numeric, factor, etc).
 
-The new components will have names that begin with \code{prefix} and a sequence of
-numbers. The variable names are padded with zeros. For example, if \code{num_comp < 10}, their names will be \code{UMAP1} - \code{UMAP9}. If \code{num_comp = 101}, the names
-would be \code{UMAP001} - \code{UMAP101}.
+The argument \code{num_comp} controls the number of components that will be retained
+(the original variables that are used to derive the components are removed from
+the data). The new components will have names that begin with \code{prefix} and a
+sequence of numbers. The variable names are padded with zeros. For example, if
+\code{num_comp < 10}, their names will be \code{UMAP1} - \code{UMAP9}. If \code{num_comp = 101},
+the names would be \code{UMAP1} - \code{UMAP101}.
 }
 \section{Tidying}{
 When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with columns \code{terms}


### PR DESCRIPTION
Ref: https://github.com/tidymodels/recipes/pull/1165

This PR uses `knitr::knit_child()` to refactor the documented section on how number prefixes work with functions that take `num_comp` arguments