### PR TITLE
Tunable target weights and initial Fixes #223 and #222

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # embed (development version)
 
-* `step_umap()` has tunable `initial` and `target_weight` arguments. (#223)
+* `step_umap()` has tunable `initial` and `target_weight` arguments. [#223](https://github.com/tidymodels/embed/issues/223), [#222](https://github.com/tidymodels/embed/issues/222))
 
 # embed 1.1.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # embed (development version)
 
+* `step_umap()` has tunable `initial` and `target_weight` arguments. (#223)
+
 # embed 1.1.4
 
 ## Improvements

--- a/R/umap.R
+++ b/R/umap.R
@@ -348,13 +348,15 @@ required_pkgs.step_umap <- function(x, ...) {
 #' @rdname tunable_embed
 tunable.step_umap <- function(x, ...) {
   tibble::tibble(
-    name = c("num_comp", "neighbors", "min_dist", "learn_rate", "epochs"),
+    name = c("num_comp", "neighbors", "min_dist", "learn_rate", "epochs", "initial", "target_weight"),
     call_info = list(
       list(pkg = "dials", fun = "num_comp", range = c(1, 10)),
       list(pkg = "dials", fun = "neighbors", range = c(5, 200)),
       list(pkg = "dials", fun = "min_dist", range = c(-4, -0.69897)),
       list(pkg = "dials", fun = "learn_rate"),
-      list(pkg = "dials", fun = "epochs", range = c(100, 700))
+      list(pkg = "dials", fun = "epochs", range = c(100, 700)),
+      list(pkg = "dials", fun = "initial_umap", values = c("spectral", "normlaplacian", "random", "lvrandom", "laplacian", "pca", "spca", "agspectral")),
+      list(pkg = "dials", fun = "target_weight", range = c(0, 1))
     ),
     source = "recipe",
     component = "step_umap",

--- a/man/step_umap.Rd
+++ b/man/step_umap.Rd
@@ -140,13 +140,15 @@ columns \code{terms} and \code{id}:
 }
 
 \section{Tuning Parameters}{
-This step has 5 tuning parameters:
+This step has 7 tuning parameters:
 \itemize{
 \item \code{num_comp}: # Components (type: integer, default: 2)
 \item \code{neighbors}: # Nearest Neighbors (type: integer, default: 15)
 \item \code{min_dist}: Min Distance between Points (type: double, default: 0.01)
 \item \code{learn_rate}: Learning Rate (type: double, default: 1)
 \item \code{epochs}: # Epochs (type: integer, default: NULL)
+\item \code{initial}: UMAP Initialization (type: character, default: spectral)
+\item \code{target_weight}: Proportion Supervised (type: double, default: 0.5)
 }
 }
 

--- a/tests/testthat/test-umap.R
+++ b/tests/testthat/test-umap.R
@@ -216,11 +216,11 @@ test_that("tunable", {
   rec_param <- tunable.step_umap(rec$steps[[1]])
   expect_equal(
     rec_param$name,
-    c("num_comp", "neighbors", "min_dist", "learn_rate", "epochs")
+    c("num_comp", "neighbors", "min_dist", "learn_rate", "epochs", "initial", "target_weight")
   )
   expect_true(all(rec_param$source == "recipe"))
   expect_true(is.list(rec_param$call_info))
-  expect_equal(nrow(rec_param), 5)
+  expect_equal(nrow(rec_param), 7L)
   expect_equal(
     names(rec_param),
     c("name", "call_info", "source", "component", "component_id")
@@ -369,11 +369,13 @@ test_that("tunable is setup to works with extract_parameter_set_dials", {
       neighbors = hardhat::tune(),
       min_dist = hardhat::tune(),
       learn_rate = hardhat::tune(),
-      epochs = hardhat::tune()
+      epochs = hardhat::tune(),
+      initial = hardhat::tune(),
+      target_weight = hardhat::tune()
     )
   
   params <- extract_parameter_set_dials(rec)
   
   expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 5L)
+  expect_identical(nrow(params), 7L)
 })


### PR DESCRIPTION
Adds `target_weight` and `initial` (via `dials::initial_umap()`) to `step_umap()` and updating associated tests.